### PR TITLE
fix: rollback to use /query endpointn only

### DIFF
--- a/local-server/main.py
+++ b/local-server/main.py
@@ -36,8 +36,8 @@ from models.api import (
     ExchangePublicTokenResponse,
     SyncItemRequest,
     SyncItemResponse,
-    TransactionResponse,
-    AccountResponse
+    # TransactionResponse,
+    # AccountResponse
 )
 from datastore.factory import get_datastore
 from services.file import get_document_from_file
@@ -156,7 +156,7 @@ async def query_main(request: QueryRequest = Body(...)):
         )
         return QueryResponse(results=results)
     except Exception as e:
-        print("Error:", e)
+        logging.error(e, exc_info=True)
         raise HTTPException(status_code=500, detail="Internal Service Error")
 
 
@@ -283,62 +283,6 @@ async def sync_item(
 
     return SyncItemResponse(success=True, transactions=dict_transactions, accounts=dict_accounts)
 
-
-@app.get(
-    "/transactions",
-    response_model=TransactionResponse,
-)
-async def get_transactions():
-    """
-    Get most recent 20 transactions.
-    TODO: Shove to LLAMAIndex for Text to SQL
-    # https://gpt-index.readthedocs.io/en/latest/guides/tutorials/sql_guide.html#text-to-sql-basic
-    """
-    # response = datastore.query(
-    #     "What are the 20 most recent transactions?"
-    # )
-    # return response, response.extra_info['sql_query']
-    return datastore.query(
-        "SELECT * FROM transactions ORDER BY date DESC LIMIT 20"
-    )
-
-
-@app.get(
-    "/all_transactions",
-    response_model=TransactionResponse,
-)
-async def get_all_transactions():
-    """
-    Get all of the transactions.
-    TODO: Shove to LLAMAIndex for Text to SQL
-    # https://gpt-index.readthedocs.io/en/latest/guides/tutorials/sql_guide.html#text-to-sql-basic
-    """
-    # response = datastore.query(
-    #     "What are all of the transactions?"
-    # )
-    # return response, response.extra_info['sql_query']
-    return datastore.query(
-        "SELECT * FROM transactions"
-    )
-
-
-@app.get(
-    "/account",
-    response_model=AccountResponse,
-)
-async def get_account():
-    """
-    Get all of the transactions.
-    TODO: Shove to LLAMAIndex for Text to SQL
-    # https://gpt-index.readthedocs.io/en/latest/guides/tutorials/sql_guide.html#text-to-sql-basic
-    """
-    # response = datastore.query(
-    #     "What are all of my account information?"
-    # )
-    # return response, response.extra_info['sql_query']
-    return datastore.query(
-        "SELECT * FROM accounts"
-    )
 
 @app.on_event("startup")
 async def startup():

--- a/models/api.py
+++ b/models/api.py
@@ -3,8 +3,6 @@ from models.models import (
     DocumentMetadataFilter,
     Query,
     QueryResult,
-    Transaction,
-    Account
 )
 from pydantic import BaseModel
 from typing import List, Optional
@@ -62,8 +60,3 @@ class SyncItemResponse(BaseModel):
     success: bool
     transactions: List
     accounts: List
-class TransactionResponse(BaseModel):
-    transactions: List[Transaction]
-
-class AccountResponse(BaseModel):
-    account: Account


### PR DESCRIPTION
remove the /account and /transaction routes since they dont work with the `datastore.py` framework.